### PR TITLE
Inheritance, Drawer Socket Modified

### DIFF
--- a/Gamedev tv unity VR project/Assets/Scenes/VrInteraction.unity
+++ b/Gamedev tv unity VR project/Assets/Scenes/VrInteraction.unity
@@ -31447,8 +31447,8 @@ GameObject:
   - component: {fileID: 7529789952916362417}
   - component: {fileID: 902639434537121597}
   - component: {fileID: 7529789952916362420}
-  - component: {fileID: 7529789952916362418}
   - component: {fileID: 7529789952916362419}
+  - component: {fileID: 7529789952916362421}
   m_Layer: 0
   m_Name: drawerInteractable
   m_TagString: Untagged
@@ -35919,16 +35919,64 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2246684804736343260}
   m_Mesh: {fileID: -1388485733357891733, guid: d36fb5410fec9854fbf81c50394c6469, type: 3}
---- !u!114 &7529789952916362418
+--- !u!65 &7529789952916362419
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2246684804736343260}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.0000002, y: 1, z: 1.0000002}
+  m_Center: {x: 0.000015258789, y: 0, z: 0.0000038146973}
+--- !u!54 &7529789952916362420
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2246684804736343260}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &7529789952916362421
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2246684804736343260}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ad34abafad169848a38072baa96cdb2, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f05e38f1d90e694789f6c6e4c82894b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_InteractionManager: {fileID: 769733562}
@@ -36071,54 +36119,8 @@ MonoBehaviour:
   m_StartingSingleGrabTransformers: []
   m_StartingMultipleGrabTransformers: []
   m_AddDefaultGrabTransformers: 1
---- !u!65 &7529789952916362419
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2246684804736343260}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1.0000002, y: 1, z: 1.0000002}
-  m_Center: {x: 0.000015258789, y: 0, z: 0.0000038146973}
---- !u!54 &7529789952916362420
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2246684804736343260}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
+  keySocket: {fileID: 9123782383113256774}
+  isLocked: 1
 --- !u!1 &7584415455641904939
 GameObject:
   m_ObjectHideFlags: 0
@@ -37563,7 +37565,7 @@ MonoBehaviour:
   m_SelectEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7529789952916362418}
+      - m_Target: {fileID: 7529789952916362421}
         m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
         m_MethodName: set_enabled
         m_Mode: 6
@@ -37578,7 +37580,7 @@ MonoBehaviour:
   m_SelectExited:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 7529789952916362418}
+      - m_Target: {fileID: 7529789952916362421}
         m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
         m_MethodName: set_enabled
         m_Mode: 6

--- a/Gamedev tv unity VR project/Assets/Scripts/DrawerInteractable.cs
+++ b/Gamedev tv unity VR project/Assets/Scripts/DrawerInteractable.cs
@@ -4,10 +4,14 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 
-public class DrawerInteractable : MonoBehaviour
+public class DrawerInteractable : XRGrabInteractable
 {
     [SerializeField] XRSocketInteractor keySocket;
     [SerializeField] bool isLocked;
+
+    private Transform parentTransform;
+    private const string defaultLayer = "Default";
+    private const string grabLayer = "Grab";
     void Start()
     {
         if (keySocket != null)
@@ -15,6 +19,7 @@ public class DrawerInteractable : MonoBehaviour
             keySocket.selectEntered.AddListener(OnDrawerUnlocked);
             keySocket.selectExited.AddListener(OnDrawerLocked);
         }
+        parentTransform = transform.parent.transform;
     }
 
     private void OnDrawerLocked(SelectExitEventArgs arg0)
@@ -27,6 +32,23 @@ public class DrawerInteractable : MonoBehaviour
         isLocked = false;
     }
 
+    protected override void OnSelectEntered(SelectEnterEventArgs args)
+    {
+        if (isLocked)
+        {
+            transform.SetParent(parentTransform);
+        }
+        else
+        {
+            interactionLayers = InteractionLayerMask.GetMask(defaultLayer);
+        }
+    }
+
+    protected override void OnSelectExited(SelectExitEventArgs args)
+    {
+        base.OnSelectExited(args);
+        interactionLayers = InteractionLayerMask.GetMask(grabLayer);
+    }
     // Update is called once per frame
     void Update()
     {

--- a/Gamedev tv unity VR project/UserSettings/Layouts/default-2023.dwlt
+++ b/Gamedev tv unity VR project/UserSettings/Layouts/default-2023.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1536
     height: 772.8
   m_ShowMode: 4
-  m_Title: Project
+  m_Title: Game
   m_RootView: {fileID: 2}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -120,7 +120,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 9468
+  controlID: 27
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -140,12 +140,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 755.2
+    width: 1042.4
     height: 722.8
   m_MinSize: {x: 100, y: 100}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 9404
+  controlID: 28
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -163,8 +163,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 755.2
-    height: 397.6
+    width: 1042.4
+    height: 434.4
   m_MinSize: {x: 201, y: 221}
   m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 12}
@@ -183,25 +183,25 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectBrowser
+  m_Name: GameView
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 397.6
-    width: 755.2
-    height: 325.19998
-  m_MinSize: {x: 231, y: 271}
-  m_MaxSize: {x: 10001, y: 10021}
-  m_ActualView: {fileID: 14}
+    y: 434.4
+    width: 1042.4
+    height: 288.4
+  m_MinSize: {x: 201, y: 221}
+  m_MaxSize: {x: 4001, y: 4021}
+  m_ActualView: {fileID: 11}
   m_Panes:
   - {fileID: 14}
   - {fileID: 15}
   - {fileID: 16}
   - {fileID: 11}
-  m_Selected: 0
-  m_LastSelected: 3
+  m_Selected: 3
+  m_LastSelected: 0
 --- !u!114 &9
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -217,9 +217,9 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 755.2
+    x: 1042.4
     y: 0
-    width: 293.60004
+    width: 201.59998
     height: 722.8
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
@@ -243,9 +243,9 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1048.8
+    x: 1244
     y: 0
-    width: 487.19995
+    width: 292
     height: 722.8
   m_MinSize: {x: 276, y: 71}
   m_MaxSize: {x: 4001, y: 4021}
@@ -276,9 +276,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 471.2
-    width: 754.2
-    height: 304.19998
+    y: 453.4
+    width: 1041.4
+    height: 267.4
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -332,23 +332,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 754.2
-      height: 283.19998
-    m_Scale: {x: 0.32777774, y: 0.32777774}
-    m_Translation: {x: 377.1, y: 141.59999}
+      width: 1041.4
+      height: 246.4
+    m_Scale: {x: 0.2851852, y: 0.2851852}
+    m_Translation: {x: 520.7, y: 123.200005}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -1150.4747
-      y: -432.00003
-      width: 2300.9495
-      height: 864.00006
+      x: -1825.8312
+      y: -432
+      width: 3651.6624
+      height: 864
     m_MinimalGUI: 1
-  m_defaultScale: 0.32777774
-  m_LastWindowPixelSize: {x: 754.2, y: 304.19998}
+  m_defaultScale: 0.2851852
+  m_LastWindowPixelSize: {x: 1041.4, y: 267.4}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
@@ -377,8 +377,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 19
-    width: 754.2
-    height: 376.6
+    width: 1041.4
+    height: 413.4
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -933,9 +933,9 @@ MonoBehaviour:
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: 6.4243426, y: -0.77852887, z: 15.159187}
+    m_Target: {x: 3.6869998, y: 0.83, z: 14.889999}
     speed: 2
-    m_Value: {x: 0.083468884, y: 1.082, z: -1.5373939}
+    m_Value: {x: 3.6869998, y: 0.83, z: 14.889999}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -981,13 +981,13 @@ MonoBehaviour:
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: -0.122140735, y: -0.7936291, z: 0.16965573, w: -0.5713884}
+    m_Target: {x: 0.16984612, y: 0.82697463, z: -0.33703384, w: 0.4167481}
     speed: 2
-    m_Value: {x: 0.032530744, y: 0.5867267, z: -0.02359648, w: 0.8087941}
+    m_Value: {x: 0.16984612, y: 0.8269747, z: -0.33703384, w: 0.4167481}
   m_Size:
-    m_Target: 2.4892173
+    m_Target: 5.062549
     speed: 2
-    m_Value: 0.1830237
+    m_Value: 5.062549
   m_Ortho:
     m_Target: 0
     speed: 2
@@ -1041,8 +1041,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 73.6
-    width: 878.2
-    height: 267.8
+    width: 1041.4
+    height: 270.2
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1076,9 +1076,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 416.6
-    width: 754.2
-    height: 304.19998
+    y: 470.4
+    width: 1041.4
+    height: 305
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1101,7 +1101,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Mat
+    - Assets/Scripts
     m_Globs: []
     m_ProductIds: 
     m_AnyWithAssetOrigin: 0
@@ -1111,7 +1111,7 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/Mat
+  - Assets/Scripts
   m_LastFoldersGridSize: 16
   m_LastProjectPath: D:\unity VR and other projects\Gamedev tv unity Vr Project github\xr-interaction-toolkit-demo\Gamedev
     tv unity VR project
@@ -1119,9 +1119,9 @@ MonoBehaviour:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: 3a4c0100
-    m_LastClickedID: 85050
-    m_ExpandedIDs: 000000005ace00005cce00005ece000060ce000062ce000064ce000066ce000068ce0000
+    m_SelectedIDs: 44cf0000
+    m_LastClickedID: 53060
+    m_ExpandedIDs: 0000000072ce000074ce000076ce000078ce00007ace00007cce00007ece000080ce0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1150,7 +1150,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 000000005ace00005cce00005ece000060ce000062ce000064ce000066ce000068ce0000
+    m_ExpandedIDs: 0000000072ce000074ce000076ce000078ce00007ace00007cce00007ece000080ce0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1178,7 +1178,7 @@ MonoBehaviour:
   m_ListAreaState:
     m_SelectedInstanceIDs: 
     m_LastClickedInstanceID: 0
-    m_HadKeyboardFocusLastEvent: 1
+    m_HadKeyboardFocusLastEvent: 0
     m_ExpandedInstanceIDs: c6230000ee5a0000566f000012ca00008ac30000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
@@ -1230,9 +1230,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 534.4
-    width: 1227
-    height: 241
+    y: 471.2
+    width: 1041.4
+    height: 304.19998
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1269,9 +1269,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 534.4
-    width: 1227
-    height: 241
+    y: 470.4
+    width: 1041.4
+    height: 305
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1340,9 +1340,9 @@ MonoBehaviour:
     m_TextWithWhitespace: "Hierarchy\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 756.2
+    x: 1043.4
     y: 19
-    width: 291.60004
+    width: 199.59998
     height: 701.8
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1360,7 +1360,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 84f6feff2818ffff9043ffff548affffb84401003c480100
+      m_ExpandedIDs: c8faffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -1377,7 +1377,7 @@ MonoBehaviour:
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
         m_TrimLeadingAndTrailingWhitespace: 0
-        m_ClientGUIView: {fileID: 0}
+        m_ClientGUIView: {fileID: 9}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -1406,9 +1406,9 @@ MonoBehaviour:
     m_TextWithWhitespace: "Inspector\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1049.8
+    x: 1245
     y: 19
-    width: 486.19995
+    width: 291
     height: 701.8
   m_SerializedDataModeController:
     m_DataMode: 0


### PR DESCRIPTION
In this commit, we inherited drawerInteractble script from xr grab interactor and made it not grabbable when its locked by changing layers in the script by overriding the base functions